### PR TITLE
Expand Stage2

### DIFF
--- a/cpp/src/BUILD
+++ b/cpp/src/BUILD
@@ -23,14 +23,6 @@ cc_binary(
     srcs = ["hello-world-v2.cc"],
     deps = [
         ":hello-greet",
-    ],
-)
-
-cc_binary(
-    name = "stage3-hello-world",
-    srcs = ["hello-world-v3.cc"],
-    deps = [
-        ":hello-greet",
         "//cpp/lib:hello-time",
     ],
 )
@@ -46,8 +38,8 @@ cc_proto_library(
 )
 
 cc_binary(
-    name = "stage4-hello-world",
-    srcs = ["hello-world-v4.cc"],
+    name = "stage3-hello-world",
+    srcs = ["hello-world-v3.cc"],
     deps = [
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",


### PR DESCRIPTION
Collapse stage2<-stage2+stage3
stage2,3 step is much smaller than other stage steps, thus removal compactifies the complexity per stages and improves readability.